### PR TITLE
MRNetCase and MRNetCaseList: an approach to custom ItemBase and ItemList for MRNet

### DIFF
--- a/MRNet_EDA_ns.ipynb
+++ b/MRNet_EDA_ns.ipynb
@@ -737,7 +737,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The number of images in a set varies from case (patient) to case, and the dimensions of each image is the same, 256x256. Axial sequences range in length from 22 to 51; coronal, from 18 to 46; sagittal, from 19 to 46."
+    "The number of images in a set varies from case (patient) to case, and the dimensions of each image is the same, 256x256. In the sample of data collected here, axial sequences range in length from 22 to 51; coronal, from 18 to 46; sagittal, from 19 to 46."
    ]
   },
   {

--- a/mrnet_itemlist.py
+++ b/mrnet_itemlist.py
@@ -5,7 +5,7 @@ from fastai.vision import *
 class MRNetCase(ItemBase):
 
   # ItemBase.data   # this needs to be developed in parallel with the ItemList's .get method
-  # imagine that .get will return a tuple of three np.arrays, an erray for each plane
+  # imagine that .get will return a list of three np.arrays, an array for each plane
     def __init__(self, axial, coronal, sagittal):
         self.axial,self.coronal,self.sagittal = axial,coronal,sagittal
         self.obj = (axial,coronal,sagittal)
@@ -18,16 +18,39 @@ class MRNetCase(ItemBase):
         pass        
   # apply_tfms (optional)
 
+
+
 # ItemList subclass
+class MRNetCaseList(ItemList):
+
   # class variables
     # _bunch
     # _processor
     # _label_cls
 
   # __init__ arguments
+  # items for this subclass will likely be a list/iterator of Case strings
+  # rather than filenames, since each case has 3 filenames, one for each plane
+    def __init__(self, items, **kwargs):
+        super().__init__(items, **kwargs)
 
   # core methods
     # get
+    def get(self, i):
+        # i indexes self.items, which is a list of Case strings
+        case = super().get(i)
+        imagearrays = []
+        for plane in ('axial','coronal','sagittal'):
+            # self.path is available from kwargs of ItemList superclass
+            fn  = self.path/plane/(case + '.npy')
+            res = self.open(fn)
+            imagearrays.append(res)
+        assert len(imagearrays) == 3
+        return MRNetCase(*imagearrays)
+
+    # since subclassing ItemList rather than ImageList, need an open method
+    def open(self, fn): return np.load(fn)
+
     # reconstruct
     # analyze_pred
 

--- a/mrnet_itemlist.py
+++ b/mrnet_itemlist.py
@@ -1,8 +1,21 @@
 import numpy as np
+from fastai.vision import *
 
 # ItemBase subclass
-  # ItemBase.data
+class MRNetCase(ItemBase):
+
+  # ItemBase.data   # this needs to be developed in parallel with the ItemList's .get method
+  # imagine that .get will return a tuple of three np.arrays, an erray for each plane
+    def __init__(self, axial, coronal, sagittal):
+        self.axial,self.coronal,self.sagittal = axial,coronal,sagittal
+        self.obj = (axial,coronal,sagittal)
+        # for .data, initially hard-code taking the middle three slices of the sagittal series
+        # middle three grayscale slices, instead of repeating same middle slice 3x
+        smid = sagittal.shape[0]//2
+        self.data = sagittal[smid-1:smid+2,:,:]
   # __str__ representation
+    def __str__(self):
+        pass        
   # apply_tfms (optional)
 
 # ItemList subclass

--- a/mrnet_itemlist.py
+++ b/mrnet_itemlist.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+# ItemBase subclass
+  # ItemBase.data
+  # __str__ representation
+  # apply_tfms (optional)
+
+# ItemList subclass
+  # class variables
+    # _bunch
+    # _processor
+    # _label_cls
+
+  # __init__ arguments
+
+  # core methods
+    # get
+    # reconstruct
+    # analyze_pred
+
+  # advanced show methods
+    # show_xys
+    # show_xyzs


### PR DESCRIPTION
`MRNetCase` is a subclass of `ItemBase` corresponds to a single knee, or case. 
It has an .obj attribute containing the three series of images for the case from the three planes.
In this implementation, likely to be changed, the .data attribute is just the middle three slices of the sagittal image series, so that the .data can be fed into pretrained 2D image classifiers expecting 3-channel images.
Note that using the middle three slices is non-standard. Typically the pixel values from a single grayscale image are repeated across three slices to spoof the pretrained model.

`MRNetCaseList` is a direct subclass of `ItemList`, rather than a subclass of `ImageList`.
It takes an `items` list giving case numbers as strings, rather than filenames like for an `ImageList`. This is because the case numbers correspond to NumPy array files in three different directories. I assume the directories have the original structure from downloading the MRNet data.
